### PR TITLE
feat: write to files asynchronously in background goroutine

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,6 @@ name: Testing
 # Trigger on pushes, PRs (excluding documentation changes), and nightly.
 on:
   push:
-  pull_request:
   schedule:
     - cron: 0 0 * * * # daily at 00:00
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ rotated. It defaults to 100 MB.
 ### MaxAge (default: 0)
 
 Retain old log files based on the timestamp encoded in their filename.
-It defaults to 0, so will not remove old log files based on age.
+If MaxAge <= 0, that means not remove old log files based on age.
 
 Note: Remember to use `time.Duration` values.
 
@@ -157,9 +157,8 @@ Note: Remember to use `time.Duration` values.
 
 ### MaxBackups (default: 0)
 
-The maximum number of old log files to retain. The default
-is to retain all old log files (though MaxAge may still cause them to get
-deleted.)
+The maximum number of old log files to retain. If MaxBackups <= 0, that means 
+retain all old log files (though MaxAge may still cause them to be removed.)
 
 ```go
   // Remove logs except latest 7 files
@@ -171,8 +170,8 @@ deleted.)
 
 ### BufferedWrite (default: 0)
 
-If you want use buffered write, then sets the channel size to be > 0. It
-defaults to 0, so will not use buffered write.
+If you want use buffered write, then sets the channel size to be > 0.
+If BufferedWrite <= 0, that means do not use buffered write.
 
 ```go
   // Use buffered write and set channel size to 100

--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ If not provided, no link will be written.
 ### MaxInterval (default: 24 hours)
 
 Interval between file rotation. By default logs are rotated every 24 hours.
-In particular, the minimal interval unit is in time.Second level.
+In particular, the minimal interval unit is in `time.Second` level.
 
-Note: Remember to use time.Duration values.
+Note: Remember to use `time.Duration` values.
 
 ```go
   // Rotate every hour
@@ -127,10 +127,10 @@ Note: Remember to use time.Duration values.
   )
 ```
 
-### MaxSize (default: 100 megabytes)
+### MaxSize (default: 100 MB)
 
-MaxSize is the maximum size in megabytes of the log file before it gets
-rotated. It defaults to 100 megabytes.
+MaxSize is the maximum size in MB (megabytes) of the log file before it gets
+rotated. It defaults to 100 MB.
 
 ```go
   // Rotate every 10 MB
@@ -143,7 +143,7 @@ rotated. It defaults to 100 megabytes.
 ### MaxAge (default: 0)
 
 Retain old log files based on the timestamp encoded in their filename.
-The default is not to remove old log files based on age.
+It defaults to 0, so will not remove old log files based on age.
 
 Note: Remember to use `time.Duration` values.
 
@@ -166,5 +166,18 @@ deleted.)
   logrotate.New(
     "/path/to/log.%Y%m%d",
     logrotate.WithMaxBackups(7),
+  )
+```
+
+### BufferedWrite (default: 0)
+
+If you want use buffered write, then sets the channel size to be > 0. It
+defaults to 0, so will not use buffered write.
+
+```go
+  // Use buffered write and set channel size to 100
+  logrotate.New(
+    "/path/to/log.%Y%m%d",
+    logrotate.WithBufferedWrite(100),
   )
 ```

--- a/example_test.go
+++ b/example_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 )
 
 func ExampleNew() {
@@ -18,6 +19,7 @@ func ExampleNew() {
 
 	log.Printf("Hello, World!") // 13 bytes
 	log.Printf("Hello, World!") // 13 bytes
+	time.Sleep(time.Second)     // ensure alerady sink to files
 	l.Close()
 
 	files, _ := os.ReadDir(dir)

--- a/example_test.go
+++ b/example_test.go
@@ -19,7 +19,7 @@ func ExampleNew() {
 
 	log.Printf("Hello, World!") // 13 bytes
 	log.Printf("Hello, World!") // 13 bytes
-	time.Sleep(time.Second)     // ensure alerady sink to files
+	time.Sleep(time.Second)     // ensure already sink to files
 	l.Close()
 
 	files, _ := os.ReadDir(dir)

--- a/logrotate_test.go
+++ b/logrotate_test.go
@@ -36,6 +36,7 @@ func BenchmarkMaxBackups1000(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		log.Println(logline)
 	}
+	// time.Sleep(time.Second)
 }
 
 func BenchmarkMaxInterval(b *testing.B) {
@@ -57,6 +58,7 @@ func BenchmarkMaxInterval(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		log.Println(logline)
 	}
+	// time.Sleep(time.Second)
 }
 
 func BenchmarkNoRotate(b *testing.B) {
@@ -75,6 +77,7 @@ func BenchmarkNoRotate(b *testing.B) {
 		require.NoError(b, err, "Write should succeed")
 		require.Equal(b, len(logline), n, "Write length should match")
 	}
+	// time.Sleep(time.Second)
 }
 
 func TestLogRotate(t *testing.T) {
@@ -154,6 +157,7 @@ func TestLogRotate(t *testing.T) {
 			require.NoError(t, err, "l.Write should succeed")
 			require.Len(t, str, n, "l.Write should succeed")
 
+			time.Sleep(100 * time.Millisecond)
 			fn := l.currentFilename()
 			if fn == "" {
 				t.Errorf("Could not get filename %s", fn)
@@ -186,6 +190,7 @@ func TestLogRotate(t *testing.T) {
 
 			// This next Write() should trigger Rotate()
 			l.Write([]byte(str))
+			time.Sleep(100 * time.Millisecond)
 			newfn := l.currentFilename()
 			if newfn == fn {
 				t.Errorf(`New file name and old file name should not match ("%s" != "%s")`, fn, newfn)
@@ -298,7 +303,7 @@ func TestLogSetOutput(t *testing.T) {
 
 	str := "Hello, World"
 	log.Print(str)
-
+	time.Sleep(100 * time.Millisecond)
 	fn := l.currentFilename()
 	if fn == "" {
 		t.Errorf("Could not get filename %s", fn)
@@ -325,8 +330,9 @@ func TestRotationSuffixSeq(t *testing.T) {
 		require.NoError(t, err, `New should succeed`)
 
 		seen := map[string]struct{}{}
-		for i := 0; i < 10; i++ {
+		for i := 0; i < 5; i++ {
 			l.Write([]byte("Hello, World!"))
+			time.Sleep(10 * time.Millisecond)
 			require.NoError(t, l.Rotate(), "l.Rotate should succeed")
 			// Because every call to Rotate should yield a new log file,
 			// and the previous files already exist, the filenames should share
@@ -334,6 +340,7 @@ func TestRotationSuffixSeq(t *testing.T) {
 			fn := filepath.Base(l.currentFilename())
 			require.True(t, strings.HasPrefix(fn, "unchanged-pattern.log"), "prefix for all filenames should match")
 			l.Write([]byte("Hello, World!"))
+			time.Sleep(10 * time.Millisecond)
 			suffix := strings.TrimPrefix(fn, "unchanged-pattern.log")
 			expectedSuffix := fmt.Sprintf(".%d", i+1)
 			require.True(t, suffix == expectedSuffix, "expected suffix %s found %s", expectedSuffix, suffix)
@@ -362,6 +369,7 @@ func TestRotationSuffixSeq(t *testing.T) {
 		for i := 0; i < 5; i++ {
 			time.Sleep(time.Second)
 			l.Write([]byte("Hello, World!"))
+			time.Sleep(10 * time.Millisecond)
 			require.True(t, strings.HasSuffix(l.currentFilename(), ".log"), "log name should end with .log")
 			require.NoError(t, l.Rotate(), "l.Rotate should succeed")
 			// because every new Write should yield a new log file,
@@ -421,7 +429,7 @@ func TestTimeZone(t *testing.T) {
 
 func Test_CreateNewFileWhenRemovedOnWrite(t *testing.T) {
 	dir := filepath.Join(baseTestDir, "Test_CreateNewFileWhenRemovedOnWrite")
-	defer os.RemoveAll(dir)
+	// defer os.RemoveAll(dir)
 	l, err := New(
 		filepath.Join(dir, "app.%Y%m%d%H.log"),
 		WithSymlink(filepath.Join(dir, "app")),
@@ -435,7 +443,7 @@ func Test_CreateNewFileWhenRemovedOnWrite(t *testing.T) {
 
 	err = l.Close()
 	require.NoError(t, err, "Close should succeed")
-
+	time.Sleep(100 * time.Millisecond)
 	files, _ := os.ReadDir(dir)
 	require.Equal(t, 2, len(files), "should auto create new log files after removed")
 }

--- a/logrotate_test.go
+++ b/logrotate_test.go
@@ -408,10 +408,8 @@ func Test_RotationSuffixSeq(t *testing.T) {
 		for i := 0; i < 5; i++ {
 			time.Sleep(time.Second)
 			l.Write([]byte("Hello, World!"))
-			time.Sleep(20 * time.Millisecond)
 			require.True(t, strings.HasSuffix(l.currentFilename(), ".log"), "log name should end with .log")
 			require.NoError(t, l.Rotate(), "l.Rotate should succeed")
-			time.Sleep(20 * time.Millisecond)
 			// because every new Write should yield a new log file,
 			// every rotate should create a filename ending with a .1
 			require.True(t, strings.HasSuffix(l.currentFilename(), ".1"), "log name should end with .1")

--- a/logrotate_test.go
+++ b/logrotate_test.go
@@ -408,9 +408,10 @@ func Test_RotationSuffixSeq(t *testing.T) {
 		for i := 0; i < 5; i++ {
 			time.Sleep(time.Second)
 			l.Write([]byte("Hello, World!"))
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(20 * time.Millisecond)
 			require.True(t, strings.HasSuffix(l.currentFilename(), ".log"), "log name should end with .log")
 			require.NoError(t, l.Rotate(), "l.Rotate should succeed")
+			time.Sleep(20 * time.Millisecond)
 			// because every new Write should yield a new log file,
 			// every rotate should create a filename ending with a .1
 			require.True(t, strings.HasSuffix(l.currentFilename(), ".1"), "log name should end with .1")

--- a/options.go
+++ b/options.go
@@ -6,12 +6,13 @@ import (
 
 // Options is supplied as the optional arguments for New.
 type Options struct {
-	clock       Clock
-	symlink     string
-	maxInterval time.Duration
-	maxSize     int
-	maxAge      time.Duration
-	maxBackups  int
+	clock       Clock         // used to determine the current time
+	symlink     string        // linked to the current file
+	maxInterval time.Duration // maximum interval between file rotation
+	maxSize     int           // maximum size of log file before rotation
+	maxAge      time.Duration // max age to retain old log files
+	maxBackups  int           // maximum number to retain old log files
+	writeChSize int           // buffered write channel size
 }
 
 // Option is the functional option type.
@@ -25,6 +26,7 @@ func newDefaultOptions() *Options {
 		maxSize:     100 * 1024 * 1024, // 100M
 		maxAge:      0,                 // retain all old log files
 		maxBackups:  0,                 // retain all old log files
+		writeChSize: 0,                 // do not use buffered write.
 	}
 }
 
@@ -68,7 +70,7 @@ func WithMaxInterval(d time.Duration) Option {
 // WithMaxSize sets the maximum size of log file before it gets
 // rotated. 0 means that do not rotate log file based on size.
 //
-// Default: 100 megabytes
+// Default: 100 MB
 func WithMaxSize(s int) Option {
 	return func(opts *Options) {
 		opts.maxSize = s
@@ -94,5 +96,15 @@ func WithMaxAge(d time.Duration) Option {
 func WithMaxBackups(n int) Option {
 	return func(opts *Options) {
 		opts.maxBackups = n
+	}
+}
+
+// WithBufferedWrite sets the buffered write channel size. Size 0 means do not
+// use buffered write.
+//
+// Default: 0
+func WithBufferedWrite(size int) Option {
+	return func(opts *Options) {
+		opts.writeChSize = size
 	}
 }

--- a/options.go
+++ b/options.go
@@ -8,10 +8,10 @@ import (
 type Options struct {
 	clock       Clock         // used to determine the current time
 	symlink     string        // linked to the current file
-	maxInterval time.Duration // maximum interval between file rotation
-	maxSize     int           // maximum size of log file before rotation
+	maxInterval time.Duration // max interval between file rotation
+	maxSize     int           // max size of log file before rotation
 	maxAge      time.Duration // max age to retain old log files
-	maxBackups  int           // maximum number to retain old log files
+	maxBackups  int           // max number of old log files to retain
 	writeChSize int           // buffered write channel size
 }
 
@@ -68,7 +68,8 @@ func WithMaxInterval(d time.Duration) Option {
 }
 
 // WithMaxSize sets the maximum size of log file before it gets
-// rotated. 0 means that do not rotate log file based on size.
+// rotated. If MaxSize <= 0, that means not rotate log file based
+// on size.
 //
 // Default: 100 MB
 func WithMaxSize(s int) Option {
@@ -78,8 +79,8 @@ func WithMaxSize(s int) Option {
 }
 
 // WithMaxAge sets the max age to retain old log files based on the
-// timestamp encoded in their filename. 0 means not to remove
-// old log files based on age.
+// timestamp encoded in their filename. If MaxAge <= 0, that means
+// not remove old log files based on age.
 //
 // Default: 0
 func WithMaxAge(d time.Duration) Option {
@@ -89,8 +90,8 @@ func WithMaxAge(d time.Duration) Option {
 }
 
 // WithMaxBackups sets the maximum number of old log files to retain.
-// 0 means that retain all old log files (though MaxAge may still cause
-// them to get deleted.)
+// If MaxBackups <= 0, that means retain all old log files (though
+// MaxAge may still cause them to be removed.)
 //
 // Default: 0
 func WithMaxBackups(n int) Option {
@@ -99,8 +100,8 @@ func WithMaxBackups(n int) Option {
 	}
 }
 
-// WithBufferedWrite sets the buffered write channel size. Size 0 means do not
-// use buffered write.
+// WithBufferedWrite sets the buffered write channel size.
+// If BufferedWrite <= 0, that means do not use buffered write.
 //
 // Default: 0
 func WithBufferedWrite(size int) Option {


### PR DESCRIPTION
Key challenges:
- DATA RACE: When implementing `func Write(b []byte) (n int, err error)`, we must do value-copy and then write it to writeCh to avoid the data race problem, as the inputed byte slice "b" is usually reused by the caller.
- Sink to files: How to ensure all written bytes sunk to files when Close.