### PR TITLE
fix: auto resume after removing files when encouters error "write: No space left on device"

### DIFF
--- a/test/nospace/README.md
+++ b/test/nospace/README.md
@@ -20,3 +20,8 @@ sudo docker exec -it <container-id> /bin/sh
 cd /ramdisk
 ./main
 ```
+
+list deleted files but still held by processes:
+```
+lsof -n <DIR> | grep delete
+```

--- a/test/nospace/README.md
+++ b/test/nospace/README.md
@@ -3,18 +3,18 @@ Testing "write: No space left on device" error.
 1. Build the Docker image:
 ```bash
 sudo docker build -t test-image .
-
 ```
+
 2. Run a Docker container:
 ```bash
 sudo docker run --rm -d --privileged test-image
-
 ```
+
 3. Enter a running container:
 ```bash
-sudo docker exec -it <container-name-or-id> /bin/sh
-
+sudo docker exec -it <container-id> /bin/sh
 ```
+
 4. Run `main` in dir `/ramdisk`:
 ```bash
 cd /ramdisk

--- a/test/nospace/README.md
+++ b/test/nospace/README.md
@@ -1,0 +1,22 @@
+Testing "write: No space left on device" error.
+
+1. Build the Docker image:
+```bash
+sudo docker build -t test-image .
+
+```
+2. Run a Docker container:
+```bash
+sudo docker run --rm -d --privileged test-image
+
+```
+3. Enter a running container:
+```bash
+sudo docker exec -it <container-name-or-id> /bin/sh
+
+```
+4. Run `main` in dir `/ramdisk`:
+```bash
+cd /ramdisk
+./main
+```

--- a/test/nospace/dockerfile
+++ b/test/nospace/dockerfile
@@ -1,0 +1,10 @@
+FROM golang:alpine
+
+WORKDIR /app
+
+COPY . /app
+
+RUN go build -o main main.go
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/test/nospace/entrypoint.sh
+++ b/test/nospace/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+mkdir /ramdisk
+mount -t tmpfs -o size=10m tmpfs /ramdisk
+
+cp /app/main /ramdisk/
+chmod +x /ramdisk/main
+
+cd /ramdisk
+
+while true; do sleep 30; done;

--- a/test/nospace/go.mod
+++ b/test/nospace/go.mod
@@ -1,0 +1,10 @@
+module github.com/gounknown/logrotate/test/nospace
+
+go 1.20
+
+require github.com/gounknown/logrotate v0.0.0-20240515135119-05b51fe715ad
+
+require (
+	github.com/lestrrat-go/strftime v1.0.6 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+)

--- a/test/nospace/go.sum
+++ b/test/nospace/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/gounknown/logrotate v0.0.0-20240515135119-05b51fe715ad h1:XPx2Py9o4CldELyBdH9qHmU9s0nc6KZlSZIbvKLMzGM=
+github.com/gounknown/logrotate v0.0.0-20240515135119-05b51fe715ad/go.mod h1:ZLpVah9ajFI46kBAmu+SbGVZBplYgyOx/Zkhe13yryQ=
+github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
+github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc h1:RKf14vYWi2ttpEmkA4aQ3j4u9dStX2t4M8UM6qqNsG8=
+github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc/go.mod h1:kopuH9ugFRkIXf3YoqHKyrJ9YfUFsckUU9S7B+XP+is=
+github.com/lestrrat-go/strftime v1.0.6 h1:CFGsDEt1pOpFNU+TJB0nhz9jl+K0hZSLE205AhTIGQQ=
+github.com/lestrrat-go/strftime v1.0.6/go.mod h1:f7jQKgV5nnJpYgdEasS+/y7EsTb8ykN2z68n3TtcTaw=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/test/nospace/main.go
+++ b/test/nospace/main.go
@@ -11,6 +11,7 @@ import (
 func main() {
 	l, err := logrotate.New(
 		"_logs/app.%Y%m%d%H%M.log",
+		logrotate.WithSymlink("_logs/app"),
 		logrotate.WithMaxInterval(time.Minute),
 	)
 	if err != nil {

--- a/test/nospace/main.go
+++ b/test/nospace/main.go
@@ -10,9 +10,9 @@ import (
 // test "write: No space left on device"
 func main() {
 	l, err := logrotate.New(
-		"_logs/app.%Y%m%d%H%M.log",
+		"_logs/app.%Y%m%d%H.log",
 		logrotate.WithSymlink("_logs/app"),
-		logrotate.WithMaxInterval(time.Minute),
+		logrotate.WithMaxInterval(time.Hour),
 	)
 	if err != nil {
 		panic(err)

--- a/test/nospace/main.go
+++ b/test/nospace/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/gounknown/logrotate"
+)
+
+// test "write: No space left on device"
+func main() {
+	l, err := logrotate.New(
+		"_logs/app.%Y%m%d%H%M.log",
+		logrotate.WithMaxInterval(time.Minute),
+	)
+	if err != nil {
+		panic(err)
+	}
+	defer l.Close()
+
+	log.SetOutput(l)
+
+	data := make([]byte, 1024*1024) // 1 MB
+	for {
+		time.Sleep(time.Second)
+		log.Println(data)
+	}
+}


### PR DESCRIPTION
- [x] close #10

## Problem: Write() guarantee not satisfied
```
// Write writes len(b) bytes from b to the File.
// It returns the number of bytes written and an error, if any.
// Write returns a non-nil error when n != len(b).
func (f *File) Write(b []byte) (n int, err error) {
```

But after calling `l.file.Write(b)`, the returned none nil `err` may be overwitten by the next logic `err = l.openExistingOrNew(writeLen)`.
https://github.com/gounknown/logrotate/blob/05b51fe715adb236f1771fce84317a6452bcf86f/logrotate.go#L146-L151